### PR TITLE
Remove trailing backslash in conda container setup

### DIFF
--- a/data-science-stack.Dockerfile
+++ b/data-science-stack.Dockerfile
@@ -50,7 +50,7 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x
     && chmod 755 /run-jupyter \
     && mkdir -p ${NOTEBOOKS_DIR} \
     && cd ${NOTEBOOKS_DIR} \
-    && git clone --recursive --single-branch --depth 1 --branch branch-${RAPIDS_VERSION} https://github.com/rapidsai/notebooks.git \
+    && git clone --recursive --single-branch --depth 1 --branch branch-${RAPIDS_VERSION} https://github.com/rapidsai/notebooks.git
 
 # Create Conda environment
 


### PR DESCRIPTION
Fixes the following issue with trailing backslash in `data-science-stack.Dockerfile`:

### Steps to Reproduce

`./data-science-stack build-container`

```
The command '/bin/sh -c curl https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -k -o /miniconda.sh     
&& sh /miniconda.sh -b -p ${CONDA_ROOT}     
&& rm -f /miniconda.sh     
&& echo "conda ${CONDA_VERSION}" >> /conda/conda-meta/pinned     
&& ${CONDA_ROOT}/bin/conda init bash     
&& echo "#!/bin/bash\n      source /conda/bin/activate data-science-stack-${STACK_VERSION}\n      jupyter-notebook --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token='' --notebook-dir=${NOTEBOOKS_DIR}" > /run-jupyter     && chmod 755 /run-jupyter     && mkdir -p ${NOTEBOOKS_DIR}    
&& cd ${NOTEBOOKS_DIR}     
&& git clone --recursive --single-branch --depth 1 --branch branch-${RAPIDS_VERSION} https://github.com/rapidsai/notebooks.git COPY environment-pinned.yaml /' returned a non-zero code: 129
###NV### Fri Feb 14 17:28:47 PST 2020 #### END Building Container
```

### After this PR

```
$ ./data-science-stack build-container
...
Step 24/24 : CMD ["/run-jupyter" ]
 ---> Running in 99a4ca64f756
Removing intermediate container 99a4ca64f756
 ---> c9d72bc1b978
Successfully built c9d72bc1b978
Successfully tagged data-science-stack:2.1.0
###NV### Fri Feb 14 18:01:48 PST 2020 #### END Building Container

```

Signed-off-by: Ryan McCormick rmccormick@nvidia.com

CC @beberg 