### PR TITLE
add fastparquet

### DIFF
--- a/environments/data-science-stack.env
+++ b/environments/data-science-stack.env
@@ -14,6 +14,7 @@ conda-forge::cmake
 conda-forge::dask-kubernetes
 conda-forge::dask-jobqueue
 conda-forge::dask-labextension
+conda-forge::fastparquet
 conda-forge::flatbuffers
 conda-forge::gcsfs
 conda-forge::hypothesis


### PR DESCRIPTION
I know there is flexibility in creating your own environments (https://github.com/NVIDIA/data-science-stack/blob/master/environments/README.md) but I would like to request [fastparquet](https://github.com/dask/fastparquet) in the data-science-stack.env as I think other users may benefit from it. In my case I was testing:
```
df = dd.read_parquet("gs://dask-nyc-taxi/yellowtrip.parquet",
                     engine="fastparquet",
                     storage_options={"token": "anon"})
````

