### PR TITLE
Respect NOTEBOOKS_DIR if set in the user's environment

### DIFF
--- a/data-science-stack
+++ b/data-science-stack
@@ -17,7 +17,8 @@ DEFAULT_ENVIRONMENT="data-science-stack"
 LOGFILE=data-science-stack.log
 
 CONDA_ROOT=${HOME}/conda
-NOTEBOOKS_DIR=${HOME}/data-science-stack-${STACK_VERSION}
+DEFAULT_NOTEBOOKS_DIR=${HOME}/data-science-stack-${STACK_VERSION}
+NOTEBOOKS_DIR=${NOTEBOOKS_DIR:-$DEFAULT_NOTEBOOKS_DIR}
 
 if [ -f /etc/redhat-release ]; then
   if grep -q -i "release 7" /etc/redhat-release ; then


### PR DESCRIPTION
With this commit applied, the `run-jupyter` task will respect a `NOTEBOOKS_DIR` value set in the user's environment, applying the default value only if the user's environment doesn't specify one.

Signed-off-by: William Benton <willb@nvidia.com>