### PR TITLE
fix missing dep preventing docker service from starting

### DIFF
--- a/data-science-stack
+++ b/data-science-stack
@@ -460,7 +460,8 @@ install_docker () {
 
     sudo yum install -y \
       docker-ce \
-      nvidia-container-toolkit
+      nvidia-container-toolkit \
+      iptables
     sudo systemctl enable docker
     if [ "$WSL" = true ] 
     then


### PR DESCRIPTION
observed with - Docker version 20.10.3, build 48d30b5

observed error - failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER: Iptables not found