### PR TITLE
Fix cuda installation for ubuntu

### DIFF
--- a/data-science-stack
+++ b/data-science-stack
@@ -317,7 +317,7 @@ install_cuda () {
       sudo dpkg -i cuda-repo-ubuntu1804-11-4-local_11.4.1-470.57.02-1_amd64.deb
       sudo apt-key add /var/cuda-repo-ubuntu1804-11-4-local/7fa2af80.pub
       sudo apt-get update
-      sudo apt-get -y install cuda
+      sudo apt-get -y install cuda-toolkit-11-4
     else
       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
       sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
@@ -325,7 +325,7 @@ install_cuda () {
       sudo dpkg -i cuda-repo-ubuntu2004-11-4-local_11.4.1-470.57.02-1_amd64.deb
       sudo apt-key add /var/cuda-repo-ubuntu2004-11-4-local/7fa2af80.pub
       sudo apt-get update
-      sudo apt-get -y install cuda
+      sudo apt-get -y install cuda-toolkit-11-4
     fi
   else
     if [ $OS_FLAVOR$OS_RELEASE_MAJOR = "rhel7" ]; then

--- a/data-science-stack
+++ b/data-science-stack
@@ -311,21 +311,21 @@ install_cuda () {
   set -e
   if [ $OS_FLAVOR = "ubuntu" ]; then
     if [ $OS_RELEASE = "18.04" ]; then
-      curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin \
-        -o cuda.pin
-      sudo mv cuda.pin /etc/apt/preferences.d/cuda-repository-pin-600
-      sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
-      sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+      sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      wget https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda-repo-ubuntu1804-11-4-local_11.4.1-470.57.02-1_amd64.deb
+      sudo dpkg -i cuda-repo-ubuntu1804-11-4-local_11.4.1-470.57.02-1_amd64.deb
+      sudo apt-key add /var/cuda-repo-ubuntu1804-11-4-local/7fa2af80.pub
       sudo apt-get update
-      sudo apt-get -y install cuda-toolkit-11-2
+      sudo apt-get -y install cuda
     else
-      curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin \
-        -o cuda.pin
-      sudo mv cuda.pin /etc/apt/preferences.d/cuda-repository-pin-600
-      sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
-      sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+      sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      wget https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda-repo-ubuntu2004-11-4-local_11.4.1-470.57.02-1_amd64.deb
+      sudo dpkg -i cuda-repo-ubuntu2004-11-4-local_11.4.1-470.57.02-1_amd64.deb
+      sudo apt-key add /var/cuda-repo-ubuntu2004-11-4-local/7fa2af80.pub
       sudo apt-get update
-      sudo apt-get -y install cuda-toolkit-11-2
+      sudo apt-get -y install cuda
     fi
   else
     if [ $OS_FLAVOR$OS_RELEASE_MAJOR = "rhel7" ]; then


### PR DESCRIPTION
This PR updates the CUDA installation steps for both ubuntu 18.04 and 20.04 according with the [official guide](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu)

Fixes https://github.com/NVIDIA/data-science-stack/issues/122